### PR TITLE
feat: add game skeleton with demo and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/Content/Cards/sample_slime_knight_E.json
+++ b/Content/Cards/sample_slime_knight_E.json
@@ -1,0 +1,13 @@
+{
+  "id":"slime_knight_001_E",
+  "display_name":"Gelatinous Page",
+  "set":"Dungeon Depths",
+  "rank":"E",
+  "rarity":"Common",
+  "role":"Tank",
+  "stats":{"atk":1,"hp":6,"spd":0.8},
+  "ability":{"id":"absorb_split","text":"Absorb damage equal to DEF each round. On death, spawn 2 Mini-Slimes."},
+  "traits":["ooze","knight"],
+  "art_tags":["green slime","battered pauldron","torchlit corridor"],
+  "flavor":"Once a squire. Now mostly pudding."
+}

--- a/Content/Packs/core_pack.json
+++ b/Content/Packs/core_pack.json
@@ -1,0 +1,6 @@
+{
+  "pack_id":"core_v1",
+  "cards_per_pack":5,
+  "rarity_odds":{"Common":0.65,"Uncommon":0.25,"Rare":0.08,"Mythic":0.02},
+  "pity":{"rare_at":10,"mythic_at":30}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# GRIND//FUSE
+
+Prototype skeleton for the GRIND//FUSE auto‑battler. This repository starts the codebase with
+sample content, core models, and pack opening + fusion logic.
+
+## Project Structure
+
+```
+Content/
+  Cards/        # sample card JSON
+  Packs/        # pack odds + pity thresholds
+
+game/           # Python modules implementing ranks, cards, and pack opening
+
+tests/          # unit tests covering fusion and pity logic
+```
+
+## Quickstart
+
+1. Ensure Python 3.10+ is installed.
+2. Install development dependencies (pytest only):
+   ```bash
+   pip install pytest
+   ```
+3. Run tests:
+   ```bash
+   pytest
+   ```
+
+4. Run the tiny demonstration:
+   ```bash
+   python demo.py
+   ```
+
+These basics demonstrate the core 10→1 fusion mechanic and pack pity system.

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,24 @@
+"""Run a tiny demonstration of pack opening and fusion."""
+
+import json
+from pathlib import Path
+from game.card import Card, fuse
+from game.pack import PackOpener
+
+
+def main():
+    data = json.loads(Path("Content/Cards/sample_slime_knight_E.json").read_text())
+    base = Card(**data)
+    cards = [base for _ in range(10)]
+    fused = fuse(cards)
+    print(f"Fused into {fused.id} with atk={fused.stats['atk']}")
+
+    odds = {"Common": 0.9, "Uncommon": 0.1}
+    pity = {"rare_at": 10, "mythic_at": 30}
+    opener = PackOpener(odds, pity)
+    rarities = opener.open_pack()
+    print(f"Opened pack rarities: {rarities}")
+
+
+if __name__ == "__main__":
+    main()

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -1,0 +1,5 @@
+"""Core logic for GRIND//FUSE demo slice."""
+
+from . import ranks, card, pack
+
+__all__ = ["ranks", "card", "pack"]

--- a/game/card.py
+++ b/game/card.py
@@ -1,0 +1,49 @@
+"""Card model and fusion helpers."""
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+from . import ranks
+
+
+@dataclass
+class Card:
+    id: str
+    display_name: str
+    set: str
+    rank: str
+    rarity: str
+    role: str
+    stats: Dict[str, float]
+    ability: Dict[str, str]
+    traits: List[str] = field(default_factory=list)
+    art_tags: List[str] = field(default_factory=list)
+    flavor: str = ""
+
+    def power(self) -> int:
+        return ranks.power(self.stats.get("atk", ranks.POWER_BASE), self.rank)
+
+
+def fuse(cards: List[Card]) -> Card:
+    """Fuse cards of the same id and rank into the next rank."""
+    if len(cards) != ranks.FUSION_COST:
+        raise ValueError("Need exactly 10 cards to fuse")
+    first = cards[0]
+    if any(c.id != first.id or c.rank != first.rank for c in cards):
+        raise ValueError("Cards must share id and rank")
+    fused_rank = ranks.next_rank(first.rank)
+    fused_stats = {k: v * 10 for k, v in first.stats.items()}
+    fused_id = f"{first.id[:-2]}_{fused_rank}" if first.id.endswith(f"_{first.rank}") else f"{first.id}_{fused_rank}"
+    return Card(
+        id=fused_id,
+        display_name=first.display_name,
+        set=first.set,
+        rank=fused_rank,
+        rarity=first.rarity,
+        role=first.role,
+        stats=fused_stats,
+        ability=first.ability,
+        traits=first.traits,
+        art_tags=first.art_tags,
+        flavor=first.flavor,
+    )

--- a/game/pack.py
+++ b/game/pack.py
@@ -1,0 +1,42 @@
+"""Pack opening with pity counters."""
+
+import random
+from typing import Dict, List, Optional
+
+RARITY_ORDER = ["Common", "Uncommon", "Rare", "Mythic"]
+
+
+class PackOpener:
+    def __init__(self, rarity_odds: Dict[str, float], pity: Dict[str, int], cards_per_pack: int = 5, rng: Optional[random.Random] = None):
+        self.rarity_odds = rarity_odds
+        self.pity = pity
+        self.cards_per_pack = cards_per_pack
+        self.rng = rng or random.Random()
+        self.packs_since = {"Rare": 0, "Mythic": 0}
+
+    def _roll_rarity(self) -> str:
+        r = self.rng.random()
+        cumulative = 0.0
+        for rarity in RARITY_ORDER:
+            cumulative += self.rarity_odds.get(rarity, 0)
+            if r < cumulative:
+                return rarity
+        return RARITY_ORDER[0]
+
+    def open_pack(self) -> List[str]:
+        rarities = [self._roll_rarity() for _ in range(self.cards_per_pack)]
+        # Apply pity for Mythic then Rare
+        for rarity in ["Mythic", "Rare"]:
+            threshold = self.pity.get(f"{rarity.lower()}_at")
+            if threshold is None:
+                continue
+            if self.packs_since[rarity] + 1 >= threshold and rarity not in rarities:
+                rarities[-1] = rarity
+        # update counters
+        highest = max(rarities, key=RARITY_ORDER.index)
+        for rarity in ["Rare", "Mythic"]:
+            if RARITY_ORDER.index(highest) >= RARITY_ORDER.index(rarity):
+                self.packs_since[rarity] = 0
+            else:
+                self.packs_since[rarity] += 1
+        return rarities

--- a/game/ranks.py
+++ b/game/ranks.py
@@ -1,0 +1,19 @@
+"""Rank model utilities."""
+
+RANKS = ["E", "F", "D", "C", "B", "A", "S", "SS", "SSS"]
+FUSION_COST = 10
+POWER_BASE = 1
+
+rank_to_index = {r: i for i, r in enumerate(RANKS)}
+
+
+def power(base_power: int, rank: str) -> int:
+    """Return power scaled by rank using the 10x gospel."""
+    return int(base_power * (10 ** rank_to_index[rank]))
+
+
+def next_rank(rank: str) -> str:
+    idx = rank_to_index[rank]
+    if idx + 1 >= len(RANKS):
+        raise ValueError("Cannot fuse beyond highest rank")
+    return RANKS[idx + 1]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from game.card import Card, fuse
+
+
+def load_sample_card():
+    data = json.loads(Path("Content/Cards/sample_slime_knight_E.json").read_text())
+    return Card(**data)
+
+
+def test_fusion_promotes_rank_and_stats():
+    base = load_sample_card()
+    cards = [base for _ in range(10)]
+    fused = fuse(cards)
+    assert fused.rank == "F"
+    assert fused.stats["atk"] == base.stats["atk"] * 10
+    assert fused.id.endswith("_F")

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1,0 +1,14 @@
+from game.pack import PackOpener
+import random
+
+
+def test_rare_pity_triggers_on_tenth_pack():
+    odds = {"Common": 1.0}
+    pity = {"rare_at": 10, "mythic_at": 30}
+    opener = PackOpener(odds, pity, rng=random.Random(0))
+    for _ in range(9):
+        rarities = opener.open_pack()
+        assert all(r == "Common" for r in rarities)
+    tenth = opener.open_pack()
+    assert "Rare" in tenth
+    assert opener.packs_since["Rare"] == 0


### PR DESCRIPTION
## Summary
- scaffold core directories with sample card and pack config
- implement card fusion and pack opener with pity counters
- add tiny demo, unit tests, and README quickstart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be76b34280832da7ce852571488699