### PR TITLE
feat: add card library and collection management

### DIFF
--- a/Content/Cards/fire_salamancer_E.json
+++ b/Content/Cards/fire_salamancer_E.json
@@ -1,0 +1,13 @@
+{
+  "id":"fire_salamancer_001_E",
+  "display_name":"Fire Salamancer",
+  "set":"Dungeon Depths",
+  "rank":"E",
+  "rarity":"Mythic",
+  "role":"DPS",
+  "stats":{"atk":4,"hp":4,"spd":1.1},
+  "ability":{"id":"ignite_chain","text":"Attacks ignite adjacent foes."},
+  "traits":["reptile","mage"],
+  "art_tags":["flaming salamander","arcane runes","lava pool"],
+  "flavor":"Wields volcanic fury with reckless glee."
+}

--- a/Content/Cards/pebble_imp_E.json
+++ b/Content/Cards/pebble_imp_E.json
@@ -1,0 +1,13 @@
+{
+  "id":"pebble_imp_001_E",
+  "display_name":"Pebble Imp",
+  "set":"Dungeon Depths",
+  "rank":"E",
+  "rarity":"Common",
+  "role":"Tank",
+  "stats":{"atk":1,"hp":5,"spd":1.0},
+  "ability":{"id":"taunt","text":"Taunts the opposing unit."},
+  "traits":["imp","earth"],
+  "art_tags":["small rock creature","mischievous grin","cave"],
+  "flavor":"Throws itself into danger with rocky enthusiasm."
+}

--- a/Content/Cards/royal_slime_E.json
+++ b/Content/Cards/royal_slime_E.json
@@ -1,0 +1,13 @@
+{
+  "id":"royal_slime_001_E",
+  "display_name":"Royal Slime",
+  "set":"Dungeon Depths",
+  "rank":"E",
+  "rarity":"Rare",
+  "role":"Tank",
+  "stats":{"atk":1,"hp":10,"spd":0.7},
+  "ability":{"id":"split_taunt","text":"Taunt the front enemy. On death, spawn 2 Mini-Slimes."},
+  "traits":["ooze","royal"],
+  "art_tags":["purple slime","tiny crown","marble floor"],
+  "flavor":"A gelatinous monarch of dubious lineage."
+}

--- a/Content/Cards/torch_moth_E.json
+++ b/Content/Cards/torch_moth_E.json
@@ -1,0 +1,13 @@
+{
+  "id":"torch_moth_001_E",
+  "display_name":"Torch Moth",
+  "set":"Dungeon Depths",
+  "rank":"E",
+  "rarity":"Uncommon",
+  "role":"Support",
+  "stats":{"atk":2,"hp":3,"spd":1.2},
+  "ability":{"id":"ignite","text":"Apply 1 burn each attack."},
+  "traits":["insect","fire"],
+  "art_tags":["glowing moth","ember wings","dark cavern"],
+  "flavor":"Guides the lost with a gentle blaze."
+}

--- a/demo.py
+++ b/demo.py
@@ -1,26 +1,28 @@
-"""Run a tiny demonstration of pack opening, fusion, and battle."""
+"""Run a tiny demonstration of pack opening, collection fusion, and battle."""
 
-import json
-from pathlib import Path
-from game.card import Card, fuse
-from game.pack import PackOpener
 from game.battle import simulate_battle
+from game.collection import Collection
+from game.library import CardLibrary
+from game.pack import CardPackOpener
 
 
 def main():
-    data = json.loads(Path("Content/Cards/sample_slime_knight_E.json").read_text())
-    base = Card(**data)
-    cards = [base for _ in range(10)]
-    fused = fuse(cards)
+    library = CardLibrary("Content/Cards")
+    collection = Collection()
+
+    base = library.get("slime_knight_001_E")
+    for _ in range(10):
+        collection.add(base)
+    fused = collection.fuse_card(base)
     print(f"Fused into {fused.id} with atk={fused.stats['atk']}")
 
     odds = {"Common": 0.9, "Uncommon": 0.1}
     pity = {"rare_at": 10, "mythic_at": 30}
-    opener = PackOpener(odds, pity)
-    rarities = opener.open_pack()
-    print(f"Opened pack rarities: {rarities}")
+    opener = CardPackOpener(library, odds, pity)
+    cards = opener.open_pack_cards()
+    print("Opened pack: " + ", ".join(c.display_name for c in cards))
 
-    winner = simulate_battle([fused]*3, [base]*3)
+    winner = simulate_battle([fused] * 3, [base] * 3)
     print(f"Battle winner: Team {winner}")
 
 

--- a/game/collection.py
+++ b/game/collection.py
@@ -1,0 +1,29 @@
+"""Manage a player's card collection and handle fusions."""
+
+from collections import defaultdict
+from typing import Dict
+
+from .card import Card, fuse
+from . import ranks
+
+
+class Collection:
+    def __init__(self):
+        self.counts: Dict[str, int] = defaultdict(int)
+
+    def add(self, card: Card, count: int = 1) -> None:
+        self.counts[card.id] += count
+
+    def count(self, card_id: str) -> int:
+        return self.counts.get(card_id, 0)
+
+    def can_fuse(self, card_id: str) -> bool:
+        return self.count(card_id) >= ranks.FUSION_COST
+
+    def fuse_card(self, card: Card) -> Card:
+        if not self.can_fuse(card.id):
+            raise ValueError("Insufficient copies to fuse")
+        self.counts[card.id] -= ranks.FUSION_COST
+        fused = fuse([card] * ranks.FUSION_COST)
+        self.counts[fused.id] += 1
+        return fused

--- a/game/library.py
+++ b/game/library.py
@@ -1,0 +1,34 @@
+"""Load and query card data from JSON files."""
+
+import json
+import random
+from pathlib import Path
+from typing import Dict, List
+
+from .card import Card
+
+
+class CardLibrary:
+    """Simple in-memory index of all cards."""
+
+    def __init__(self, cards_dir: str = "Content/Cards"):
+        self.cards: Dict[str, Card] = {}
+        self.by_rarity: Dict[str, List[Card]] = {}
+        self._load(cards_dir)
+
+    def _load(self, cards_dir: str) -> None:
+        for path in Path(cards_dir).glob("*.json"):
+            data = json.loads(path.read_text())
+            card = Card(**data)
+            self.cards[card.id] = card
+            self.by_rarity.setdefault(card.rarity, []).append(card)
+
+    def get(self, card_id: str) -> Card:
+        return self.cards[card_id]
+
+    def random_by_rarity(self, rarity: str, rng: random.Random | None = None) -> Card:
+        rng = rng or random
+        pool = self.by_rarity.get(rarity)
+        if not pool:
+            raise ValueError(f"No cards with rarity {rarity}")
+        return rng.choice(pool)

--- a/game/pack.py
+++ b/game/pack.py
@@ -40,3 +40,15 @@ class PackOpener:
             else:
                 self.packs_since[rarity] += 1
         return rarities
+
+
+class CardPackOpener(PackOpener):
+    """Pack opener that returns actual cards using a card library."""
+
+    def __init__(self, library, rarity_odds: Dict[str, float], pity: Dict[str, int], cards_per_pack: int = 5, rng: Optional[random.Random] = None):
+        super().__init__(rarity_odds, pity, cards_per_pack, rng)
+        self.library = library
+
+    def open_pack_cards(self):
+        rarities = self.open_pack()
+        return [self.library.random_by_rarity(r, self.rng) for r in rarities]

--- a/tests/test_card_pack.py
+++ b/tests/test_card_pack.py
@@ -1,0 +1,14 @@
+import random
+
+from game.library import CardLibrary
+from game.pack import CardPackOpener
+
+
+def test_open_pack_returns_cards():
+    library = CardLibrary("Content/Cards")
+    odds = {"Common": 1.0}
+    pity = {}
+    opener = CardPackOpener(library, odds, pity, rng=random.Random(0))
+    cards = opener.open_pack_cards()
+    assert len(cards) == opener.cards_per_pack
+    assert all(c.rarity == "Common" for c in cards)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,0 +1,15 @@
+from game.collection import Collection
+from game.library import CardLibrary
+
+
+def test_collection_fuses_when_enough_copies():
+    library = CardLibrary("Content/Cards")
+    base = library.get("slime_knight_001_E")
+    coll = Collection()
+    for _ in range(10):
+        coll.add(base)
+    assert coll.can_fuse(base.id)
+    fused = coll.fuse_card(base)
+    assert fused.rank == "F"
+    assert coll.count(base.id) == 0
+    assert coll.count(fused.id) == 1


### PR DESCRIPTION
## Summary
- load cards from JSON and query by rarity
- manage player collection with fusion logic
- open packs to yield card objects and add sample card data
- refresh demo and tests

## Testing
- `pytest`
- `python demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68be7b405adc832da3b6660d005fad26