### PR TITLE
Add basic trait synergies to battle simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Content/
 
 game/           # Python modules implementing ranks, cards, and pack opening
 
-tests/          # unit tests covering fusion and pity logic
+tests/          # unit tests covering fusion, pity, and combat synergies
 ```
 
 ## Quickstart

--- a/game/battle.py
+++ b/game/battle.py
@@ -1,19 +1,37 @@
-"""Simple 3v3 lane battle simulator."""
+"""Simple 3v3 lane battle simulator with light trait synergies."""
 
-from dataclasses import dataclass
-from typing import List
+from dataclasses import dataclass, field
+from typing import Dict, List
 
 from .card import Card
+
+# Basic synergy rules inspired by the design overview. Each entry maps a trait
+# to the minimum count required on a team and the bonus it grants when active.
+# Bonuses are intentionally lightweight to keep the simulation fast and
+# deterministic.
+SYNERGY_RULES: Dict[str, Dict[str, float]] = {
+    # Two oozes regenerate 1 HP at the end of each round.
+    "ooze": {"count": 2, "regen": 1},
+    # Two knights gain +1 attack.
+    "knight": {"count": 2, "atk_bonus": 1},
+}
 
 
 @dataclass
 class Unit:
     card: Card
     hp: float
+    atk_bonus: float = 0.0
+    regen: float = 0.0
+    max_hp: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Track max HP so regeneration does not exceed the starting value.
+        self.max_hp = self.hp
 
     @property
     def atk(self) -> float:
-        return self.card.stats.get("atk", 0)
+        return self.card.stats.get("atk", 0) + self.atk_bonus
 
     @property
     def spd(self) -> float:
@@ -26,6 +44,20 @@ class Unit:
 def _is_team_alive(team: List[Unit]) -> bool:
     return any(u.alive() for u in team)
 
+
+def _apply_synergies(team: List[Unit]) -> None:
+    """Apply trait-based bonuses to a team of units."""
+    trait_counts: Dict[str, int] = {}
+    for unit in team:
+        for trait in unit.card.traits:
+            trait_counts[trait] = trait_counts.get(trait, 0) + 1
+    for trait, count in trait_counts.items():
+        rule = SYNERGY_RULES.get(trait)
+        if rule and count >= rule.get("count", 0):
+            for unit in team:
+                if trait in unit.card.traits:
+                    unit.atk_bonus += rule.get("atk_bonus", 0)
+                    unit.regen += rule.get("regen", 0)
 
 def simulate_battle(team_a_cards: List[Card], team_b_cards: List[Card]) -> str:
     """Run a deterministic battle returning "A" or "B" winner.
@@ -42,6 +74,10 @@ def simulate_battle(team_a_cards: List[Card], team_b_cards: List[Card]) -> str:
         team_a.append(Unit(Card(id="dummy", display_name="", set="", rank="E", rarity="Common", role="", stats={"atk":0,"hp":0,"spd":1.0}, ability={}), 0))
     while len(team_b) < 3:
         team_b.append(Unit(Card(id="dummy", display_name="", set="", rank="E", rarity="Common", role="", stats={"atk":0,"hp":0,"spd":1.0}, ability={}), 0))
+
+    # apply synergies after teams are assembled
+    _apply_synergies(team_a)
+    _apply_synergies(team_b)
 
     while _is_team_alive(team_a) and _is_team_alive(team_b):
         order = []
@@ -64,5 +100,9 @@ def simulate_battle(team_a_cards: List[Card], team_b_cards: List[Card]) -> str:
             if target is None:
                 return side
             target.hp -= attacker.atk
+        # apply end-of-round regeneration
+        for unit in team_a + team_b:
+            if unit.alive() and unit.regen:
+                unit.hp = min(unit.max_hp, unit.hp + unit.regen)
         # loop until one team dead
     return "A" if _is_team_alive(team_a) else "B"

--- a/tests/test_synergy.py
+++ b/tests/test_synergy.py
@@ -1,0 +1,29 @@
+from game.card import Card
+from game.battle import simulate_battle
+
+def make_card(id_suffix: str, traits=None):
+    return Card(
+        id=f"test_{id_suffix}_E",
+        display_name="",
+        set="",
+        rank="E",
+        rarity="Common",
+        role="",
+        stats={"atk":1, "hp":3, "spd":1.0},
+        ability={},
+        traits=traits or [],
+        art_tags=[],
+        flavor="",
+    )
+
+def test_ooze_synergy_regenerates():
+    ooze = make_card("ooze", traits=["ooze"])
+    generic = make_card("generic")
+    winner = simulate_battle([ooze, ooze], [generic, generic])
+    assert winner == "A"
+
+def test_knight_synergy_attack_bonus():
+    knight = make_card("knight", traits=["knight"])
+    generic = make_card("generic")
+    winner = simulate_battle([knight, knight], [generic, generic])
+    assert winner == "A"


### PR DESCRIPTION
## Summary
- implement simple trait synergy system granting bonuses like ooze regen and knight attack boosts
- regenerate units between rounds and apply bonuses when team has 2+ matching traits
- test combat synergies for ooze regeneration and knight attack buff

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be7d543a34832d9679bac7aaf1fd1b