### PR TITLE
Implement duplicate protection and pack config loading

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -3,7 +3,7 @@
 from game.battle import simulate_battle
 from game.collection import Collection
 from game.library import CardLibrary
-from game.pack import CardPackOpener
+from game.pack import load_card_pack
 
 
 def main():
@@ -16,9 +16,11 @@ def main():
     fused = collection.fuse_card(base)
     print(f"Fused into {fused.id} with atk={fused.stats['atk']}")
 
-    odds = {"Common": 0.9, "Uncommon": 0.1}
-    pity = {"rare_at": 10, "mythic_at": 30}
-    opener = CardPackOpener(library, odds, pity)
+    # Preload another card to demonstrate duplicate protection during pack opening.
+    pebble = library.get("pebble_imp_001_E")
+    collection.add(pebble, 10)
+
+    opener = load_card_pack(library, "Content/Packs/core_pack.json", collection=collection)
     cards = opener.open_pack_cards()
     print("Opened pack: " + ", ".join(c.display_name for c in cards))
 

--- a/game/library.py
+++ b/game/library.py
@@ -3,7 +3,7 @@
 import json
 import random
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Callable, Optional
 
 from .card import Card
 
@@ -26,9 +26,24 @@ class CardLibrary:
     def get(self, card_id: str) -> Card:
         return self.cards[card_id]
 
-    def random_by_rarity(self, rarity: str, rng: random.Random | None = None) -> Card:
+    def random_by_rarity(
+        self,
+        rarity: str,
+        rng: random.Random | None = None,
+        predicate: Optional[Callable[[Card], bool]] = None,
+    ) -> Card:
+        """Return a random card of the given rarity.
+
+        An optional ``predicate`` can be supplied to filter the pool. If the
+        predicate filters out all cards the full pool is used as a fallback so
+        callers always receive a card of the desired rarity.
+        """
         rng = rng or random
         pool = self.by_rarity.get(rarity)
         if not pool:
             raise ValueError(f"No cards with rarity {rarity}")
+        if predicate:
+            filtered = [c for c in pool if predicate(c)]
+            if filtered:
+                pool = filtered
         return rng.choice(pool)

--- a/game/pack.py
+++ b/game/pack.py
@@ -1,7 +1,11 @@
-"""Pack opening with pity counters."""
+"""Pack opening with pity counters and duplicate protection."""
 
+import json
 import random
+from pathlib import Path
 from typing import Dict, List, Optional
+
+from . import ranks
 
 RARITY_ORDER = ["Common", "Uncommon", "Rare", "Mythic"]
 
@@ -43,12 +47,54 @@ class PackOpener:
 
 
 class CardPackOpener(PackOpener):
-    """Pack opener that returns actual cards using a card library."""
+    """Pack opener that returns actual cards using a card library.
 
-    def __init__(self, library, rarity_odds: Dict[str, float], pity: Dict[str, int], cards_per_pack: int = 5, rng: Optional[random.Random] = None):
+    If a ``collection`` is supplied, the opener will attempt to avoid granting an
+    11th copy of a card by filtering out cards for which the collection already
+    holds ``ranks.FUSION_COST`` copies. This implements the soft duplicate
+    protection described in the design overview.
+    """
+
+    def __init__(
+        self,
+        library,
+        rarity_odds: Dict[str, float],
+        pity: Dict[str, int],
+        cards_per_pack: int = 5,
+        rng: Optional[random.Random] = None,
+        collection=None,
+    ):
         super().__init__(rarity_odds, pity, cards_per_pack, rng)
         self.library = library
+        self.collection = collection
 
     def open_pack_cards(self):
         rarities = self.open_pack()
-        return [self.library.random_by_rarity(r, self.rng) for r in rarities]
+        cards = []
+        for r in rarities:
+            card = self.library.random_by_rarity(
+                r,
+                self.rng,
+                predicate=(
+                    None
+                    if self.collection is None
+                    else lambda c: self.collection.count(c.id) < ranks.FUSION_COST
+                ),
+            )
+            cards.append(card)
+            if self.collection is not None:
+                self.collection.add(card)
+        return cards
+
+
+def load_card_pack(library, path: str, rng: Optional[random.Random] = None, collection=None) -> CardPackOpener:
+    """Load pack configuration from JSON and return a ``CardPackOpener``."""
+    data = json.loads(Path(path).read_text())
+    return CardPackOpener(
+        library,
+        data.get("rarity_odds", {}),
+        data.get("pity", {}),
+        cards_per_pack=data.get("cards_per_pack", 5),
+        rng=rng,
+        collection=collection,
+    )

--- a/tests/test_card_pack.py
+++ b/tests/test_card_pack.py
@@ -1,5 +1,6 @@
 import random
 
+from game.collection import Collection
 from game.library import CardLibrary
 from game.pack import CardPackOpener
 
@@ -12,3 +13,15 @@ def test_open_pack_returns_cards():
     cards = opener.open_pack_cards()
     assert len(cards) == opener.cards_per_pack
     assert all(c.rarity == "Common" for c in cards)
+
+
+def test_duplicate_protection_skips_eleventh_copy():
+    library = CardLibrary("Content/Cards")
+    coll = Collection()
+    blocked = library.get("pebble_imp_001_E")
+    coll.add(blocked, 10)
+    odds = {"Common": 1.0}
+    pity = {}
+    opener = CardPackOpener(library, odds, pity, rng=random.Random(0), collection=coll)
+    cards = opener.open_pack_cards()
+    assert all(c.id != blocked.id for c in cards)


### PR DESCRIPTION
## Summary
- allow CardLibrary to filter random draws with predicates
- add soft duplicate protection and JSON pack loading to CardPackOpener
- update demo and tests to use new pack loader and prevent 11th copies

## Testing
- `pytest`
- `python demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68be8468dce4832da37b1fce8ea0ffb4